### PR TITLE
emitReady  & buffer events until first connected peer

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,15 @@ Add the following dna per every cell which needs to communicate through a channe
   "source": "organic-plasma-channel",
   "port": Number,
   "channelName": String,
-  "swarmOpts": {},
+  "swarmOpts": {
+    "utp": false,
+    "tcp": true,
+    "dns": true,
+    "dht": false,
+  },
   "emitReady": String || false,
+  "readyOnListening": false,
+  "disableNoPeersEventBuffer": false,
   "log": false,
   "debug": false,
   "disabled": false
@@ -28,7 +35,8 @@ Add the following dna per every cell which needs to communicate through a channe
 * `port` is *optional* but if provided should be different for different cells on single host
 * `emitReady` accepts `false` or `String` values, when String is provided it will be used to emit a chemical of that type when ready and listening for peers
 * `swarmOpts` is *optional* and if present will be passed as-is to [`discovery-swarm`'s constructor](https://github.com/mafintosh/discovery-swarm#var-sw--swarmopts)
-
+* `readyOnListening` - default is `false` - emits ready on first connected peer; `true` - old behavior, emits ready on swarm listening event
+* `disableNoPeersEventBuffer` - default is `false` - all events emitted to the channel will be buffered and pumped back when there is at least one connected peer; `true` - old behavior, no buffering
 ## use
 
 Having cell1 and cell2 both configured to join in `channel1`.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Add the following dna per every cell which needs to communicate through a channe
     "utp": false,
     "tcp": true,
     "dns": true,
-    "dht": false,
+    "dht": false
   },
   "emitReady": String || false,
   "readyOnListening": false,

--- a/test/e2e/buffer-early-events.test.js
+++ b/test/e2e/buffer-early-events.test.js
@@ -1,0 +1,61 @@
+var PlasmaChannel = require('../../index')
+var Plasma = require('organic-plasma')
+describe('e2e buffer early events', function () {
+  var plasmaMaster
+  var plasmaChild
+  var channelName = 'default'
+
+  var callbackCount = 0
+  var handleCount = 0
+
+  it('setup master channel', function (next) {
+    plasmaMaster = new Plasma()
+    plasmaMaster.on('masterReady', function (c) { setTimeout(next, 100) })
+    plasmaMaster.channel = new PlasmaChannel(plasmaMaster, {
+      swarmOpts: require('./swarmOpts'),
+      channelName: channelName,
+      emitReady: 'masterReady',
+      readyOnListening: true, // emitReady on listening event, not on first connected peer
+    })
+  })
+  it('emit from master', function (next) {
+    plasmaMaster.emit({
+      type: 'c1',
+      channel: channelName
+    }, function (err, result) {
+      expect(err).to.not.exist
+      expect(result).to.eq(true)
+      callbackCount += 1
+    })
+    next()
+  })
+  it('setup child channel', function (next) {
+    plasmaChild = new Plasma()
+    plasmaChild.on('childReady', function (c) { setTimeout(next, 0) })
+    plasmaChild.on({
+      channel: channelName
+    }, function (c, respond) {
+      expect(c.type).to.eq('c1')
+      handleCount += 1
+      respond(null, true)
+    })
+    plasmaChild.channel = new PlasmaChannel(plasmaChild, {
+      swarmOpts: require('./swarmOpts'),
+      channelName: channelName,
+      emitReady: 'childReady',
+      readyOnListening: true, // emitReady on listening event, not on first connected peer
+    })
+  })
+  it('buffered event emit from master still received', function (next) {
+    setTimeout(function () {
+      expect(callbackCount).to.eq(1)
+      expect(handleCount).to.eq(1)
+      next()
+    }, 100)
+  })
+  after(function (next) {
+    plasmaMaster.emit('kill')
+    plasmaChild.emit('kill')
+    setTimeout(next, 0)
+  })
+})

--- a/test/e2e/general.test.js
+++ b/test/e2e/general.test.js
@@ -7,30 +7,22 @@ describe('e2e general', function () {
   beforeEach(function (next) {
     plasmaMaster = new Plasma()
     plasmaChild = new Plasma()
-    next()
-  })
-  beforeEach(function (next) {
-    plasmaMaster.on('masterReady', function (c) { next() })
     plasmaMaster.channel = new PlasmaChannel(plasmaMaster, {
+      swarmOpts: require('./swarmOpts'),
       channelName: channelName,
       emitReady: 'masterReady'
     })
-  })
-  beforeEach(function (next) {
-    plasmaChild.on('childReady', function (c) { next() })
+    plasmaChild.on('childReady', function (c) { setTimeout(next, 100) })
     plasmaChild.channel = new PlasmaChannel(plasmaChild, {
+      swarmOpts: require('./swarmOpts'),
       channelName: channelName,
       emitReady: 'childReady'
     })
   })
-  beforeEach(function (next) {
-    // wait channels to resolve and connect
-    setTimeout(next, 1000)
-  })
   afterEach(function (next) {
     plasmaMaster.emit('kill')
     plasmaChild.emit('kill')
-    setTimeout(next, 1000)
+    setTimeout(next, 0)
   })
 
   it('sends chemical from child to master (w/o feedback)', function (next) {
@@ -173,6 +165,6 @@ describe('e2e general', function () {
       expect(c1CallbackHit).to.eq(1)
       expect(c2CallbackHit).to.eq(1)
       next()
-    }, 1000)
+    }, 100)
   })
 })

--- a/test/e2e/many-cells.test.js
+++ b/test/e2e/many-cells.test.js
@@ -9,38 +9,28 @@ describe('e2e many cells', function () {
     plasma1 = new Plasma()
     plasma2 = new Plasma()
     plasma3 = new Plasma()
-    next()
-  })
-  beforeEach(function (next) {
-    plasma1.on('ready', function (c) { next() })
+    plasma1.on('ready', function (c) { setTimeout(next, 100) })
     plasma1.channel = new PlasmaChannel(plasma1, {
+      swarmOpts: require('./swarmOpts'),
       channelName: channelName,
       emitReady: 'ready'
     })
-  })
-  beforeEach(function (next) {
-    plasma2.on('ready', function (c) { next() })
     plasma2.channel = new PlasmaChannel(plasma2, {
+      swarmOpts: require('./swarmOpts'),
       channelName: channelName,
       emitReady: 'ready'
     })
-  })
-  beforeEach(function (next) {
-    plasma3.on('ready', function (c) { next() })
     plasma3.channel = new PlasmaChannel(plasma3, {
+      swarmOpts: require('./swarmOpts'),
       channelName: channelName,
       emitReady: 'ready'
     })
-  })
-  beforeEach(function (next) {
-    // wait channels to resolve and connect
-    setTimeout(next, 1000)
   })
   afterEach(function (next) {
     plasma1.emit('kill')
     plasma2.emit('kill')
     plasma3.emit('kill')
-    setTimeout(next, 1000)
+    setTimeout(next, 0)
   })
 
   it('sends chemical from one instance to others (w/o feedback)', function (next) {
@@ -49,6 +39,10 @@ describe('e2e many cells', function () {
       counter += 1
       if (counter === 2) next()
     }
+    plasma3.emit({
+      type: 'c1',
+      channel: channelName
+    })
     plasma1.on({
       channel: channelName
     }, function (c) {
@@ -60,27 +54,11 @@ describe('e2e many cells', function () {
     }, function (c) {
       expect(c.type).to.eq('c1')
       checkNext()
-    })
-    plasma3.emit({
-      type: 'c1',
-      channel: channelName
     })
   })
 
   it('sends chemical from one instance to others (with feedback)', function (next) {
     var counter = 0
-    plasma1.on({
-      channel: channelName
-    }, function (c, respond) {
-      expect(c.type).to.eq('c1')
-      respond(null, 1)
-    })
-    plasma2.on({
-      channel: channelName
-    }, function (c, respond) {
-      expect(c.type).to.eq('c1')
-      respond(null, 1)
-    })
     plasma3.emit({
       type: 'c1',
       channel: channelName,
@@ -91,6 +69,18 @@ describe('e2e many cells', function () {
       if (counter === 2) {
         next()
       }
+    })
+    plasma1.on({
+      channel: channelName
+    }, function (c, respond) {
+      expect(c.type).to.eq('c1')
+      respond(null, 1)
+    })
+    plasma2.on({
+      channel: channelName
+    }, function (c, respond) {
+      expect(c.type).to.eq('c1')
+      respond(null, 1)
     })
   })
 })

--- a/test/e2e/one-after-another.test.js
+++ b/test/e2e/one-after-another.test.js
@@ -1,17 +1,21 @@
 var PlasmaChannel = require('../../index')
 var Plasma = require('organic-plasma')
-describe('e2e general emit only once', function () {
+describe('e2e one after another', function () {
   var plasmaMaster
   var plasmaChild
   var channelName = 'default'
   beforeEach(function (next) {
     plasmaMaster = new Plasma()
-    plasmaChild = new Plasma()
+    plasmaMaster.on('masterReady', function (c) { setTimeout(next, 100) })
     plasmaMaster.channel = new PlasmaChannel(plasmaMaster, {
       swarmOpts: require('./swarmOpts'),
       channelName: channelName,
-      emitReady: 'masterReady'
+      emitReady: 'masterReady',
+      readyOnListening: true, // emitReady on listening event, not on first connected peer
     })
+  })
+  beforeEach(function (next) {
+    plasmaChild = new Plasma()
     plasmaChild.on('childReady', function (c) { setTimeout(next, 100) })
     plasmaChild.channel = new PlasmaChannel(plasmaChild, {
       swarmOpts: require('./swarmOpts'),

--- a/test/e2e/swarmOpts.js
+++ b/test/e2e/swarmOpts.js
@@ -1,0 +1,6 @@
+module.exports = {
+  utp: false,
+  tcp: true,
+  dns: true,
+  dht: false,
+}


### PR DESCRIPTION
### General

1. Changed the default behaviour of `emitReady` on swarm `listening`
event (can be toggled to old behaviour by `dna.readyOnListening=true`
to - on first connected peer.
2. Buffer and pump back (with a repeat with timeout of 100ms) all
events emitted when there're no connected peers (can be disabled with
`dna.disableNoPeersEventBuffer=true`)

### Misc

- updated test specs, added 2 new ones & swarmOpts for fast start/stop
of the swarm channel :)
- updated README.md

---

![image](https://user-images.githubusercontent.com/616057/38941318-fc3025ba-4334-11e8-8199-1898efa1ef04.png)
