### PR TITLE
Proper cleanup on kill

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,6 +145,8 @@ module.exports = function (plasma, dna) {
   })
 
   plasma.on('kill', function (c, next) {
+    clearTimeout(bufferPumpTimeoutHandle)
+    bufferedEvents.length = 0
     sw.destroy(function () {
       connectionPool.length = 0
       next()


### PR DESCRIPTION
This PR fixes an issue where the channel is started from one process and right after closed (kill), the node process hangs because of the setTimeout (it's not unreferenced).