### PR TITLE
Fix for a memory leak

### DIFF
--- a/lib/json-socket.js
+++ b/lib/json-socket.js
@@ -165,12 +165,12 @@ var delegates = [
   'end',
   'setTimeout',
   'setKeepAlive',
-  'removeListener'
+  'removeListener',
+  'listenerCount',
 ]
 
 delegates.forEach(function (method) {
   JsonSocket.prototype[method] = function () {
-    this._socket[method].apply(this._socket, arguments)
-    return this
+    return this._socket[method].apply(this._socket, arguments)
   }
 })

--- a/test/e2e/many-cells.test.js
+++ b/test/e2e/many-cells.test.js
@@ -27,6 +27,12 @@ describe('e2e many cells', function () {
     })
   })
   afterEach(function (next) {
+    expect(plasma3.channel.getConnectionPool().length).to.eq(2)
+    expect(plasma3.channel.getConnectionPool()[0].listenerCount('message')).to.eq(1)
+    expect(plasma3.channel.getConnectionPool()[1].listenerCount('message')).to.eq(1)
+    next()
+  })
+  afterEach(function (next) {
     plasma1.emit('kill')
     plasma2.emit('kill')
     plasma3.emit('kill')
@@ -37,8 +43,44 @@ describe('e2e many cells', function () {
     var counter = 0
     var checkNext = function () {
       counter += 1
-      if (counter === 2) next()
+      if (counter === 10 * 2) next()
     }
+    plasma3.emit({
+      type: 'c1',
+      channel: channelName
+    })
+    plasma3.emit({
+      type: 'c1',
+      channel: channelName
+    })
+    plasma3.emit({
+      type: 'c1',
+      channel: channelName
+    })
+    plasma3.emit({
+      type: 'c1',
+      channel: channelName
+    })
+    plasma3.emit({
+      type: 'c1',
+      channel: channelName
+    })
+    plasma3.emit({
+      type: 'c1',
+      channel: channelName
+    })
+    plasma3.emit({
+      type: 'c1',
+      channel: channelName
+    })
+    plasma3.emit({
+      type: 'c1',
+      channel: channelName
+    })
+    plasma3.emit({
+      type: 'c1',
+      channel: channelName
+    })
     plasma3.emit({
       type: 'c1',
       channel: channelName
@@ -66,7 +108,7 @@ describe('e2e many cells', function () {
     }, function (err, result) {
       expect(err).to.not.exist
       counter += result
-      if (counter === 2) {
+      if (counter === 3) {
         next()
       }
     })
@@ -80,7 +122,7 @@ describe('e2e many cells', function () {
       channel: channelName
     }, function (c, respond) {
       expect(c.type).to.eq('c1')
-      respond(null, 1)
+      respond(null, 2)
     })
   })
 })


### PR DESCRIPTION
When emitting to a channel, and the emit is missing a callback, default callback function is passed (noop, from organic-plasma@2.x.x) causing the swarm to attach onceChemical listener, which never gets called - because of the default callback.

---

Without the fix

```
  e2e many cells
(node:6786) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 message listeners added. Use emitter.setMaxListeners() to increase limit
(node:6786) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 message listeners added. Use emitter.setMaxListeners() to increase limit
    ✓ sends chemical from one instance to others (w/o feedback)
    1) "after each" hook for "sends chemical from one instance to others (w/o feedback)"

  e2e one after another
    ✓ sends chemical from master to child (with feedback) (101ms)


  14 passing (2s)
  1 failing

  1) e2e many cells "after each" hook for "sends chemical from one instance to others (w/o feedback)":

      AssertionError: expected 11 to equal 1
      + expected - actual

      -11
      +1

      at Context.<anonymous> (test/e2e/many-cells.test.js:31:80)
```