### PR TITLE
Yet another memory leaks related updates. Rework onceChemical handling.

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -15,18 +15,36 @@ module.exports = function (connection, dna) {
       }
     })
   }
-  jsonConnection.onceChemical = function (pattern, callback) {
-    var callbackCalled = false
-    var handler = function (c) {
-      if (dna.debug) console.log(dna.port, 'onceChemical', c, pattern)
-      if (plasmaUtils.deepEqual(pattern, c) && !callbackCalled) {
-        callbackCalled = true
-        callback(c)
-        jsonConnection.removeListener('message', handler)
+  var onces = []
+  var oncesHandler = function (c) {
+    for (var once of onces) {
+      if (plasmaUtils.deepEqual(once.pattern, c)) {
+        if (dna.debug) console.log(dna.port, 'onceChemical', c, once.pattern)
+        once.callback(c)
+        onces = onces.filter(o => !plasmaUtils.deepEqual(o.pattern, once.pattern))
+        break
       }
     }
-
-    jsonConnection.on('message', handler)
+  }
+  jsonConnection.on('message', oncesHandler)
+  jsonConnection.cleanOnces = function (all) {
+    if (all) {
+      onces.length = 0
+      if (jsonConnection && jsonConnection._socket) {
+        jsonConnection._socket.destroy()
+      }
+      jsonConnection = null
+    } else {
+      var now = new Date().getTime()
+      onces = onces.filter(o => o.ts + (299 * 1000) > now)
+    }
+  }
+  jsonConnection.onceChemical = function (pattern, callback) {
+    onces.push({
+      pattern,
+      callback,
+      ts: new Date().getTime(),
+    })
   }
   return jsonConnection
 }

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -4,10 +4,12 @@ var plasmaUtils = require('organic-plasma/lib/utils')
 module.exports = function (connection, dna) {
   var jsonConnection = new JsonSocket(connection)
   jsonConnection.emitChemical = function (c) {
+    if (!jsonConnection) return
     if (dna.debug) console.log(dna.port, 'emitChemical', c)
     jsonConnection.sendMessage(c)
   }
   jsonConnection.onChemical = function (pattern, callback) {
+    if (!jsonConnection) return
     jsonConnection.on('message', function (c) {
       if (dna.debug) console.log(dna.port, 'onChemical', c, pattern)
       if (plasmaUtils.deepEqual(pattern, c)) {
@@ -17,6 +19,7 @@ module.exports = function (connection, dna) {
   }
   var onces = []
   var oncesHandler = function (c) {
+    if (!jsonConnection) return
     for (var once of onces) {
       if (plasmaUtils.deepEqual(once.pattern, c)) {
         if (dna.debug) console.log(dna.port, 'onceChemical', c, once.pattern)

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -43,6 +43,7 @@ module.exports = function (connection, dna) {
     }
   }
   jsonConnection.onceChemical = function (pattern, callback) {
+    if (!jsonConnection) return
     onces.push({
       pattern,
       callback,

--- a/test/e2e/buffer-early-events.test.js
+++ b/test/e2e/buffer-early-events.test.js
@@ -51,7 +51,7 @@ describe('e2e buffer early events', function () {
       expect(callbackCount).to.eq(1)
       expect(handleCount).to.eq(1)
       next()
-    }, 100)
+    }, 200)
   })
   after(function (next) {
     plasmaMaster.emit('kill')

--- a/test/e2e/emit-once-memory-leak.test.js
+++ b/test/e2e/emit-once-memory-leak.test.js
@@ -1,14 +1,32 @@
 var PlasmaChannel = require('../../index')
 var Plasma = require('organic-plasma')
-describe('e2e many cells', function () {
+describe('e2e emit once memory leak', function () {
   var plasma1
   var plasma2
   var plasma3
+  var plasma4
+  var plasma5
+  var plasma6
+  var plasma7
+  var plasma8
+  var plasma9
+  var plasma10
+  var plasma11
+  var plasma12
   var channelName = 'default'
   beforeEach(function (next) {
     plasma1 = new Plasma()
     plasma2 = new Plasma()
     plasma3 = new Plasma()
+    plasma4 = new Plasma()
+    plasma5 = new Plasma()
+    plasma6 = new Plasma()
+    plasma7 = new Plasma()
+    plasma8 = new Plasma()
+    plasma9 = new Plasma()
+    plasma10 = new Plasma()
+    plasma11 = new Plasma()
+    plasma12 = new Plasma()
     plasma1.on('ready', function (c) { setTimeout(next, 100) })
     plasma1.channel = new PlasmaChannel(plasma1, {
       swarmOpts: require('./swarmOpts'),
@@ -25,9 +43,54 @@ describe('e2e many cells', function () {
       channelName: channelName,
       emitReady: 'ready'
     })
+    plasma4.channel = new PlasmaChannel(plasma4, {
+      swarmOpts: require('./swarmOpts'),
+      channelName: channelName,
+      emitReady: 'ready'
+    })
+    plasma5.channel = new PlasmaChannel(plasma5, {
+      swarmOpts: require('./swarmOpts'),
+      channelName: channelName,
+      emitReady: 'ready'
+    })
+    plasma6.channel = new PlasmaChannel(plasma6, {
+      swarmOpts: require('./swarmOpts'),
+      channelName: channelName,
+      emitReady: 'ready'
+    })
+    plasma7.channel = new PlasmaChannel(plasma7, {
+      swarmOpts: require('./swarmOpts'),
+      channelName: channelName,
+      emitReady: 'ready'
+    })
+    plasma8.channel = new PlasmaChannel(plasma8, {
+      swarmOpts: require('./swarmOpts'),
+      channelName: channelName,
+      emitReady: 'ready'
+    })
+    plasma9.channel = new PlasmaChannel(plasma9, {
+      swarmOpts: require('./swarmOpts'),
+      channelName: channelName,
+      emitReady: 'ready'
+    })
+    plasma10.channel = new PlasmaChannel(plasma10, {
+      swarmOpts: require('./swarmOpts'),
+      channelName: channelName,
+      emitReady: 'ready'
+    })
+    plasma11.channel = new PlasmaChannel(plasma11, {
+      swarmOpts: require('./swarmOpts'),
+      channelName: channelName,
+      emitReady: 'ready'
+    })
+    plasma12.channel = new PlasmaChannel(plasma12, {
+      swarmOpts: require('./swarmOpts'),
+      channelName: channelName,
+      emitReady: 'ready'
+    })
   })
   afterEach(function (next) {
-    expect(plasma3.channel.getConnectionPool().length).to.eq(2)
+    expect(plasma3.channel.getConnectionPool().length).to.eq(11)
     expect(plasma3.channel.getConnectionPool()[0].listenerCount('message')).to.eq(2)
     expect(plasma3.channel.getConnectionPool()[1].listenerCount('message')).to.eq(2)
     next()
@@ -36,6 +99,15 @@ describe('e2e many cells', function () {
     plasma1.emit('kill')
     plasma2.emit('kill')
     plasma3.emit('kill')
+    plasma4.emit('kill')
+    plasma5.emit('kill')
+    plasma6.emit('kill')
+    plasma7.emit('kill')
+    plasma8.emit('kill')
+    plasma9.emit('kill')
+    plasma10.emit('kill')
+    plasma11.emit('kill')
+    plasma12.emit('kill')
     setTimeout(next, 0)
   })
 


### PR DESCRIPTION
Yet another memory leaks related updates.

Rework onceChemical handling.
Don't use dedicated socket.message listeners, since we can easily reach max (when we have more peers cross-connected), and we should clear timed-out handlers by hand, in order to not leak memory.

Instead, use dedicated array of "once" handlers and single message listener. Emitting will iterate and search for appropriate handler, if found - call it, and remove the handler for the array.

Also, a "global" and single instance of `cleanOncesTimeout` interval is used, to clear out timed-out handlers.

Can you please bump the version in the `package.json` also + tag and version? Thanks ❤️ 